### PR TITLE
Use term "LXC" in output when LXC is checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Check Options:
                         Mode to use.
   -n NODE, --node NODE  Node to check (necessary for all modes except cluster
                         and version)
-  --name NAME           Name of storage or vm
+  --name NAME           Name of storage, vm, or container
   --vmid VMID           ID of virtual machine or container
   --expected-vm-status {running,stopped,paused}
                         Expected VM status
@@ -157,6 +157,12 @@ Without specifying a node name:
 ```
 ./check_pve.py -u <API_USER> -p <API_PASSWORD> -e <API_ENDPOINT> -m vm --name test-vm
 OK - VM 'test-vm' is running on 'node1'|cpu=1.85%;; memory=8.33%;;
+```
+
+You can also pass a container name for the VM check:
+```
+./check_pve.py -u <API_USER> -p <API_PASSWORD> -e <API_ENDPOINT> -m vm --name test-lxc
+OK - LXC 'test-lxc' on node 'node1' is running|cpu=0.11%;; memory=13.99%;;
 ```
 
 With memory thresholds:

--- a/check_pve.py
+++ b/check_pve.py
@@ -156,18 +156,23 @@ class CheckPVE:
         found = False
         for vm in data:
             if vm['name'] == idx or vm['vmid'] == idx:
+                # Check if VM (default) or LXC
+                vm_type = "VM"
+                if vm['type'] == 'lxc':
+                    vm_type = "LXC"
+
                 if vm['status'] != expected_state:
-                    self.check_message = "VM '{}' is {} (expected: {})".format(vm['name'], vm['status'], expected_state)
+                    self.check_message = "{} '{}' is {} (expected: {})".format(vm_type, vm['name'], vm['status'], expected_state)
                     if not self.options.ignore_vm_status:
                         self.check_result = CheckState.CRITICAL
                 else:
                     if self.options.node and self.options.node != vm['node']:
-                        self.check_message = "VM '{}' is {}, but located on node '{}' instead of '{}'" \
-                            .format(vm['name'], expected_state, vm['node'], self.options.node)
+                        self.check_message = "{} '{}' is {}, but located on node '{}' instead of '{}'" \
+                            .format(vm_type, vm['name'], expected_state, vm['node'], self.options.node)
                         self.check_result = CheckState.WARNING
                     else:
-                        self.check_message = "VM '{}' on node '{}' is {}" \
-                            .format(vm['name'], vm['node'], expected_state)
+                        self.check_message = "{} '{}' on node '{}' is {}" \
+                            .format(vm_type, vm['name'], vm['node'], expected_state)
 
                 if vm['status'] == 'running' and not only_status:
                     self.add_perfdata("cpu", round(vm['cpu'] * 100, 2))
@@ -186,7 +191,7 @@ class CheckPVE:
                 break
 
         if not found:
-            self.check_message = "VM '{}' not found".format(idx)
+            self.check_message = "VM or LXC named '{}' not found".format(idx)
             self.check_result = CheckState.WARNING
 
     def check_disks(self):

--- a/check_pve.py
+++ b/check_pve.py
@@ -191,7 +191,7 @@ class CheckPVE:
                 break
 
         if not found:
-            self.check_message = "VM or LXC named '{}' not found".format(idx)
+            self.check_message = "VM or LXC '{}' not found".format(idx)
             self.check_result = CheckState.WARNING
 
     def check_disks(self):

--- a/check_pve.py
+++ b/check_pve.py
@@ -536,7 +536,7 @@ class CheckPVE:
                                 help='Node to check (necessary for all modes except cluster and version)')
 
         check_opts.add_argument('--name', dest='name',
-                                help='Name of storage or vm')
+                                help='Name of storage, vm, or container')
 
         check_opts.add_argument('--vmid', dest='vmid', type=int,
                                 help='ID of virtual machine or container')


### PR DESCRIPTION
You can use the VM check for LXCs, too. Previously, the output when checking an LXC was:

./check_pve.py ... -m vm --name pihole1
OK - VM 'pihole1' on node 'proxmox3' is running|cpu=0.11%;; memory=13.52%;;

Having this patch applied, the output is changed to:

OK - LXC 'pihole1' on node 'proxmox3' is running|cpu=0%;; memory=13.5%;;

Checking a VM instead of an LXC, the output remains unchanged:

./check_pve.py ... -m vm -n proxmox3 --name icinga-alt
OK - VM 'icinga-alt' on node 'proxmox3' is running|cpu=39.71%;; memory=66.87%;;