### PR TITLE
Added VM check example for Icinga2

### DIFF
--- a/icinga2/service.conf
+++ b/icinga2/service.conf
@@ -34,6 +34,9 @@ object Host "proxmox-host.domain.example" {
 
   // Ignore these disks in health check (USB sticks, SD cards, etc.)
   vars.pve_ignore_disks = [ "sdn", "sdg" ]
+
+  vars.virtual_machines["vm-01"] = {
+  }
 }
 
 template Service "pve-service" {
@@ -125,4 +128,15 @@ apply Service "storage " for (storage => config in host.vars.pve_storage) {
 
   vars.pve_mode = "storage"
   vars.pve_resource_name = storage
+}
+
+apply Service "pve-vm " for (vm => config in host.vars.virtual_machines) {
+  import "pve-service"
+
+  vars += config
+
+  vars.pve_mode = "vm"
+  vars.pve_resource_name = vm
+
+  assign where host.vars.pve_host
 }


### PR DESCRIPTION
Slightly changed the apply block: I've adopted "vars += config" from your example.

Closes #20.