### PR TITLE
Remove pve_unit from Icinga2 service.conf file

### DIFF
--- a/icinga2/service.conf
+++ b/icinga2/service.conf
@@ -21,13 +21,11 @@ object Host "proxmox-host.domain.example" {
   address = "192.168.42.42"
 
   vars.pve_storage["flashpool"] = {
-    pve_unit = "%"
     pve_warning = 80
     pve_critical = 90
   }
 
   vars.pve_storage["diskpool"] = {
-    pve_unit = "%"
     pve_warning = 80
     pve_critical = 90
   }
@@ -114,7 +112,6 @@ apply Service "memory" {
 
   vars.pve_mode = "memory"
 
-  vars.pve_unit = "%"
   vars.pve_warning = 80
   vars.pve_critical = 90
 


### PR DESCRIPTION
The pve_unit setting was used in an older release, but is not relevant anymore.

Closes #19.