### PR TITLE
feat: add vzdump backup task check

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The ``icinga2`` folder contains the command definition and service examples for 
 
 ```
 usage: check_pve.py [-h] -e API_ENDPOINT [--api-port API_PORT] -u API_USER (-p API_PASSWORD | -t API_TOKEN) [-k] -m
-                    {cluster,version,cpu,memory,swap,storage,io_wait,updates,services,subscription,vm,vm_status,replication,disk-health,ceph-health,zfs-health,zfs-fragmentation} [-n NODE] [--name NAME] [--vmid VMID]
+                    {cluster,version,cpu,memory,swap,storage,io_wait,updates,services,subscription,vm,vm_status,replication,disk-health,ceph-health,zfs-health,zfs-fragmentation,backup} [-n NODE] [--name NAME] [--vmid VMID]
                     [--expected-vm-status {running,stopped,paused}] [--ignore-vm-status] [--ignore-service NAME] [--ignore-disk NAME] [-w THRESHOLD_WARNING] [-c THRESHOLD_CRITICAL] [-M] [-V MIN_VERSION] [--unit {GB,MB,KB,GiB,MiB,KiB,B}]
 
 Check command for PVE hosts via API
@@ -282,6 +282,22 @@ Check for specific pool:
 ```
 ./check_pve.py -u <API_USER> -p <API_PASSWORD> -e <API_ENDPOINT> -m zfs-fragmentation -n pve --name diskpool -w 40 -c 60
 WARNING - Fragmentation of ZFS pool 'diskpool' is above thresholds: 50 %|fragmentation=50%;40.0;60.0
+```
+
+**Check VZDump Backups**
+
+Check task history on all nodes:
+
+```
+./check_pve.py -u <API_USER> -p <API_PASSWORD> -e <API_ENDPOINT> -m backup
+CRITICAL - 8 backup tasks successful, 3 backup tasks failed
+```
+
+Check for specific node and time frame:
+
+```
+./check_pve.py -u <API_USER> -p <API_PASSWORD> -e <API_ENDPOINT> -m backup -n pve -c 86400
+OK - 2 backup tasks successful, 0 backup tasks failed within the last 86400.0s
 ```
 
 ## FAQ


### PR DESCRIPTION
Fixes #24

This PR implements a check mode that checks the list of completed tasks for any failed backup tasks. It also checks the `not-backed-up` API endpoint and warns if VMs are not covered by a backup schedule.

The time window inside which backup tasks should be checked can be provided with the critical threshold `delta`.

Limitations:
- The tasks API does not return any backup details apart from success/failure. Any details have to be checked in the failed tasks' logs.
- The PVE API does not seem to provide a reasonable method to map task instances to the backup schedule they were created from.
- This check is at the mercy of whatever set of tasks the `/cluster/tasks` API chooses to return. Especially long-term checks can not be done with this check, as the tasks API only provides a limited view into the past.