### PR TITLE
Add --http-debug option + disk ignore by serial

### DIFF
--- a/check_pve.py
+++ b/check_pve.py
@@ -351,6 +351,9 @@ class CheckPVE:
             if name in self.options.ignore_disks:
                 continue
 
+            if disk['serial'] in self.options.ignore_disks:
+                continue
+
             if disk["health"] == "UNKNOWN":
                 self.check_result = CheckState.WARNING
                 unknown.append({"serial": disk["serial"], "device": disk["devpath"]})


### PR DESCRIPTION
Hi, I added --http-debug option to my fork and also the possibility to ignore the disk by serial not just name (my server changes these sometimes)