### PR TITLE
fix: Fix filtering by node name in snapshot age check

### DIFF
--- a/check_pve.py
+++ b/check_pve.py
@@ -794,6 +794,8 @@ class CheckPVE:
                 node_name = vm.get("node", None)
             else:
                 node_name = self.options.node
+            if node_name != vm.get("node", None):
+                continue
             url = self.get_url(f"nodes/{node_name}/{vm_type}/{vm_id}/snapshot")
             data = self.request(url)
 


### PR DESCRIPTION
An oversight on my part, we need to iterate over VMs/containers only on the node we're filtering by not all available nodes :)