### PR TITLE
feat: allow disks to be ignored by serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ usage: check_pve.py [-h] [--version] [-e API_ENDPOINT] [--api-port API_PORT] [-u
                     -P API_PASSWORD_FILE | -t API_TOKEN | -T API_TOKEN_FILE] [-k]
                     [-m {cluster,version,cpu,memory,swap,storage,io_wait,io-wait,updates,services,subscription,vm,vm_status,vm-status,replication,disk-health,ceph-health,zfs-health,zfs-fragmentation,backup,snapshot-age,network-status,task-queue,certificate}]
                     [-n NODE] [--name NAME] [--vmid VMID] [--expected-vm-status {running,stopped,paused}]
-                    [--ignore-vmid VMID] [--ignore-vm-status] [--ignore-service NAME] [--ignore-disk NAME]
+                    [--ignore-vmid VMID] [--ignore-vm-status] [--ignore-service NAME] [--ignore-disk DISK]
                     [--ignore-pools NAME] [--ignore-interface NAME] [--ignore-no-backup]
                     [-w THRESHOLD_WARNING] [-c THRESHOLD_CRITICAL] [-M] [-V MIN_VERSION]
                     [--unit {GB,MB,KB,GiB,MiB,KiB,B}]
@@ -150,7 +150,8 @@ Check Options:
   --ignore-vm-status    Ignore VM status in checks
   --ignore-service NAME
                         Ignore service NAME in checks
-  --ignore-disk NAME    Ignore disk NAME in health check
+  --ignore-disk DISK    Ignore disk DISK in health check. Accepts either the device name (e.g. 'sdb') or the
+                        disk's serial number; matching is case-insensitive. Can be given multiple times.
   --ignore-pools NAME   Ignore VMs and containers in pool(s) NAME in checks
   --ignore-interface NAME
                         Ignore network interface NAME in network status check

--- a/check_pve.py
+++ b/check_pve.py
@@ -361,25 +361,31 @@ class CheckPVE:
             self.check_result = CheckState.WARNING
 
     def check_disks(self) -> None:
-        """Check disk health on specific Proxmox VE node."""
+        """Check disk health on specific Proxmox VE node.
+
+        Disks can be excluded from the check by device name or serial number.
+        """
         url = self.get_url(f"nodes/{self.options.node}/disks")
+
+        ignore_disks = {entry.strip().lower() for entry in self.options.ignore_disks}
 
         failed = []
         unknown = []
         disks = self.request(url + "/list")
         for disk in disks:
             name = disk["devpath"].replace("/dev/", "")
+            serial = disk.get("serial", "") or ""
 
-            if name in self.options.ignore_disks:
+            if name.lower() in ignore_disks or (serial and serial.lower() in ignore_disks):
                 continue
 
             if disk["health"] == "UNKNOWN":
                 self.check_result = CheckState.WARNING
-                unknown.append({"serial": disk["serial"], "device": disk["devpath"]})
+                unknown.append({"serial": serial, "device": disk["devpath"]})
 
             elif disk["health"] not in ("PASSED", "OK"):
                 self.check_result = CheckState.WARNING
-                failed.append({"serial": disk["serial"], "device": disk["devpath"]})
+                failed.append({"serial": serial, "device": disk["devpath"]})
 
             if disk["wearout"] != "N/A":
                 self.add_perfdata(f"wearout_{name}", disk["wearout"])
@@ -1550,8 +1556,10 @@ class CheckPVE:
             "--ignore-disk",
             dest="ignore_disks",
             action="append",
-            metavar="NAME",
-            help="Ignore disk NAME in health check",
+            metavar="DISK",
+            help="Ignore disk DISK in health check. Accepts either the device "
+            "name (e.g. 'sdb') or the disk's serial number; matching is "
+            "case-insensitive. Can be given multiple times.",
             default=[],
         )
 

--- a/icinga2/command.conf
+++ b/icinga2/command.conf
@@ -51,7 +51,7 @@ object CheckCommand "pve" {
                 "--ignore-disk" = {
                         repeat_key = true
                         value = "$pve_ignore_disks$"
-                        description = "Ignore disks in check"
+                        description = "Ignore disks in check. Can be either a sdX device name or a disk serial number."
                 }
                 "--ignore-vm-status" = {
                         set_if = "$pve_ignore_vm_status$"

--- a/tests/test_mode_disk_health.py
+++ b/tests/test_mode_disk_health.py
@@ -1,0 +1,93 @@
+from typing import Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from check_pve import CheckPVE, CheckState
+
+
+@pytest.fixture
+def disk_check(pve_instance: CheckPVE) -> CheckPVE:
+    """Configure a disk-health check with the normal initial check state."""
+    pve_instance.options = pve_instance.parse_args(
+        ["-e", "endpoint", "-u", "user", "-p", "password", "-m", "disk-health", "-n", "pve"]
+    )
+    pve_instance.check_result = CheckState.OK
+    return pve_instance
+
+
+@pytest.mark.parametrize(
+    "ignored, excluded",
+    [
+        pytest.param([], False, id="no-exclusions"),
+        pytest.param(["sdb"], True, id="device"),
+        pytest.param([" SDB "], True, id="normalized-device"),
+        pytest.param(["AbC123"], True, id="serial"),
+        pytest.param([" abc123 "], True, id="normalized-serial"),
+        pytest.param(["unrelated", "ABC123"], True, id="repeated-option"),
+        pytest.param(["abc12"], False, id="serial-prefix-does-not-match"),
+        pytest.param(["sd"], False, id="device-prefix-does-not-match"),
+    ],
+)
+@pytest.mark.parametrize("health", ["FAILED", "UNKNOWN"])
+def test_ignore_disks(
+    disk_check: CheckPVE, ignored: List[str], excluded: bool, health: str
+) -> None:
+    """Exclusions suppress both health warnings and wearout metrics."""
+    disk_check.options = disk_check.parse_args(
+        ["-e", "endpoint", "-u", "user", "-p", "password", "-m", "disk-health", "-n", "pve"]
+        + [arg for value in ignored for arg in ("--ignore-disk", value)]
+    )
+    disk = {"devpath": "/dev/sdb", "serial": "AbC123", "health": health, "wearout": 90}
+
+    with patch.object(CheckPVE, "request", return_value=[disk]):
+        disk_check.check_disks()
+
+    if excluded:
+        assert disk_check.check_result == CheckState.OK
+        assert disk_check.check_message == "All disks are healthy"
+        assert disk_check.perfdata == []
+    else:
+        assert disk_check.check_result == CheckState.WARNING
+        assert "/dev/sdb with serial 'AbC123'" in disk_check.check_message
+        assert disk_check.perfdata == ["wearout_sdb=90%;;;0;"]
+
+
+@pytest.mark.parametrize(
+    "serial_fields",
+    [
+        pytest.param({}, id="missing"),
+        pytest.param({"serial": None}, id="null"),
+        pytest.param({"serial": ""}, id="empty"),
+    ],
+)
+@pytest.mark.parametrize("health", ["FAILED", "UNKNOWN"])
+def test_missing_serial(disk_check: CheckPVE, serial_fields: Dict, health: str) -> None:
+    """Disks without serials remain reportable even with an empty exclusion."""
+    disk_check.options.ignore_disks = [""]
+    disk = {"devpath": "/dev/sdb", "health": health, "wearout": "N/A", **serial_fields}
+
+    with patch.object(CheckPVE, "request", return_value=[disk]):
+        disk_check.check_disks()
+
+    assert disk_check.check_result == CheckState.WARNING
+    assert "/dev/sdb with serial ''" in disk_check.check_message
+    assert disk_check.perfdata == []
+
+
+def test_exclusion_keeps_other_disks_checked(disk_check: CheckPVE) -> None:
+    """Serial exclusions follow renamed devices without hiding other failures."""
+    disk_check.options.ignore_disks = ["ABC123"]
+    disks = [
+        {"devpath": "/dev/sdc", "serial": "AbC123", "health": "FAILED", "wearout": 90},
+        {"devpath": "/dev/sdb", "serial": "OTHER", "health": "FAILED", "wearout": 80},
+    ]
+
+    with patch.object(CheckPVE, "request", return_value=disks):
+        disk_check.check_disks()
+
+    assert disk_check.check_result == CheckState.WARNING
+    assert disk_check.check_message == (
+        "1 of 2 disks failed the health test:\n- /dev/sdb with serial 'OTHER'\n"
+    )
+    assert disk_check.perfdata == ["wearout_sdb=80%;;;0;"]


### PR DESCRIPTION
The --ignore-disk option only matched the device name (e.g. 'sdb'), which is not stable across reboots or after a disk replacement. A disk can now also be excluded by its serial number, so the exclusion survives a change of the device name it gets assigned.

Matching is case-insensitive and tolerates surrounding whitespace for both device names and serial numbers. The metavar was renamed from NAME to DISK, since the value is no longer just a device name.

While at it, report failed and unknown disks with the safely read serial value, which avoids a KeyError if the API doesn't return a serial for a disk.

Related to #74 — same idea, but with conventional commit format and black formatting applied.